### PR TITLE
Add support for xsi:schemaLocation

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -3,6 +3,7 @@ utils = require './xml-utils'
 
 xmlValidation = /xmlns:xsi="http:\/\/www.w3.org\/2001\/XMLSchema-instance"/
 xsdPattern = /xsi:noNamespaceSchemaLocation="(.+)"/
+xsdWithNamespacePattern = /xsi:schemaLocation="\S+\s+(.+)"/
 
 module.exports =
   # Enable for XML but not for XML comments.
@@ -55,7 +56,13 @@ module.exports =
   getXsdUri: ({editor}) ->
     # Get the XSD url only if the XML ask for validation.
     txt = editor.getText()
-    if txt.match(xmlValidation) then uri = txt.match(xsdPattern)?[1] else null
+    if txt.match(xmlValidation)  
+      xsdMatch = txt.match(xsdPattern)
+      if xsdMatch then uri = xsdMatch?[1] 
+      else
+        xsdWithNamespaceMatch = txt.match(xsdWithNamespacePattern)
+        if xsdWithNamespaceMatch then uri = xsdWithNamespaceMatch?[1]        
+    else null
 
 
   ## Filter the candidate completions by prefix.


### PR DESCRIPTION
Detects XSDs using xsi:schemaLocation in addition to the current support for xsi:noNamespaceSchemaLocation.

Current implementation assumes the simplest case where only one schema uri is specified.
Example: xsi:schemaLocation="TestNamespace TestXSD.xsd"
