### PR TITLE
Fix multiple groups in complex type.

### DIFF
--- a/lib/xsdParser.coffee
+++ b/lib/xsdParser.coffee
@@ -354,14 +354,15 @@ module.exports =
           memberType = @types[t]
           type.xsdChildren.push memberType.xsdChildren[0] if memberType
 
-      # At the moment, I think it only makes sense if it replaces all the
-      # elements. Consider a group that contains a sequence of choice elements.
-      # We don't support sequence->sequence(from group)->choide->elements.
+      # Resolve all groups in type
+      newChildren = []
       for group in type.xsdChildren
         if group.childType is 'group'
           linkType = @types[group.ref]
-          type.xsdChildren = linkType.xsdChildren
-          break
+          newChildren = newChildren.concat(linkType.xsdChildren)
+        else
+          newChildren = newChildren.concat([group])
+      type.xsdChildren = newChildren
 
       # Add the attributes from the group attributes
       groups = (attr.ref for attr in type.xsdAttributes when attr.ref)


### PR DESCRIPTION
In a XSD with complex type that references multiple groups like this:

<xs:group name="g1">
    <xs:sequence>
        <xs:element name="a" type="xs:string"/>
    </xs:sequence>
</xs:group>

<xs:group name="g2">
    <xs:sequence>
        <xs:element name="b" type="xs:string"/>
    </xs:sequence>
</xs:group>

<xs:complexType name="myType">
    <xs:sequence>
        <xs:group ref="g1"/>
        <xs:group ref="g2"/>
    </xs:sequence>
</xs:complexType>

only the first group g1 is resolved for myType. So the autocompletion suggests only a tag and not the b tag.

This PR fixes it.