### PR TITLE
Fix xsd:extension to extend the base type with its elements.

### DIFF
--- a/lib/xsdParser.coffee
+++ b/lib/xsdParser.coffee
@@ -329,9 +329,13 @@ module.exports =
           atom.notifications.addError "can't find base type " + extenType.$.base
           continue
 
+        # Get extending elements to merge them with linkType children
+        extendingType = @initTypeObject null, "someType"
+        @parseComplexType extenType, extendingType
+
         type.xsdTypeName = linkType.xsdTypeName
         type.xsdChildrenMode = linkType.xsdChildrenMode
-        type.xsdChildren = linkType.xsdChildren
+        type.xsdChildren = linkType.xsdChildren.concat extendingType.xsdChildren
         type.xsdAttributes = extenAttr.concat linkType.xsdAttributes
         type.description ?= linkType.description
         type.type = linkType.type


### PR DESCRIPTION
Consider the following schema that extends complex types:

```xml
<xs:complexType name="baseType">
        <xs:sequence>
            <xs:element name="a" type="xs:string"/>
        </xs:sequence>
    </xs:complexType>

    <xs:complexType name="extendedType">
        <xs:complexContent>
            <xs:extension base="baseType">
                <xs:sequence>
                    <xs:element name="b" type="xs:string"/>
                </xs:sequence>
            </xs:extension>
        </xs:complexContent>
    </xs:complexType>

    <xs:complexType name="superExtendedType">
        <xs:complexContent>
            <xs:extension base="extendedType">
                <xs:sequence>
                    <xs:element name="c" type="xs:string"/>
                </xs:sequence>
                <xs:attribute name="attr" type="xs:string"/>
            </xs:extension>
        </xs:complexContent>
    </xs:complexType>

    <xs:element name="myElem" type="superExtendedType"/>
```

According to schema in elemenet `myElem` elements `a`, `b`, `c` can be used. This PR  fixes autocompletion to correctly offer all of them.

Please review the PR and consider pulling it to your master repo.