### PR TITLE
Fix simple content extension.

### DIFF
--- a/lib/xsdParser.coffee
+++ b/lib/xsdParser.coffee
@@ -188,6 +188,10 @@ module.exports =
     else if node.complexContent?[0].extension
       type.xsdChildrenMode = 'extension'
       type.xsdChildren = node.complexContent[0].extension[0]
+    else if node.simpleContent?[0].extension
+      type.xsdType = 'simple'
+      type.xsdChildrenMode = 'extension'
+      type.xsdChildren = node.simpleContent[0].extension[0]
     else if node.group
       type.xsdChildrenMode = 'group'
       type.xsdChildren = node.group[0]
@@ -326,8 +330,12 @@ module.exports =
         # Copy fields from base
         linkType = @types[extenType.$.base]
         if not linkType
-          atom.notifications.addError "can't find base type " + extenType.$.base
-          continue
+          # Ingore link type for simple types reffering to standard simple types like xs:string, etc.
+          if type.xsdType == 'simple' and ":" in extenType.$.base
+            linkType = @initTypeObject null, type.xsdTypeName
+          else
+            atom.notifications.addError "can't find base type " + extenType.$.base
+            continue
 
         type.xsdTypeName = linkType.xsdTypeName
         type.xsdChildrenMode = linkType.xsdChildrenMode


### PR DESCRIPTION
This PR extends autocomplete-xml package with ability to recognize simple content extension. For example when a simple type is extended with an attribute.

```xml
<xs:simpleType name="extendedType">
  <xs:extension base="xs:string">
    <xs:attribute name="myAttr" type="xs:string"/>
  </xs:extension>
</xs:simpleType>
```

The fix shoud work correcly for both standard simple types like `xs:string` and custom simples, e.g. string restrictions, etc.

Please review the PR and consider merging it to your package.