### PR TITLE
 Add support for xs:list with itemType attribute

### DIFF
--- a/lib/xsdParser.coffee
+++ b/lib/xsdParser.coffee
@@ -147,6 +147,9 @@ module.exports =
     else if node.union
       type.xsdChildrenMode = 'union'
       type.leftLabel = node.union[0].$.memberTypes
+    else if node.list
+      type.xsdChildrenMode = 'list'
+      type.leftLabel = node.list[0].$.itemType
 
     if childrenNode
       group =
@@ -365,6 +368,14 @@ module.exports =
         for t in unionTypes
           memberType = @types[t]
           type.xsdChildren.push memberType.xsdChildren[0] if memberType
+
+      # If it's a list
+      else if type.xsdChildrenMode == 'list'
+        listType = @types[type.leftLabel]
+        if not listType
+          atom.notifications.addError "can't find item type " + type.leftLabel
+          continue
+        type.xsdChildren = listType.xsdChildren
 
       # Resolve all groups in type
       newChildren = []

--- a/lib/xsdParser.coffee
+++ b/lib/xsdParser.coffee
@@ -138,7 +138,6 @@ module.exports =
     type.xsdType = 'simple'
 
     # Get the node that contains the children
-    # TODO: Support list children.
     # TODO: Support more restriction types.
     if node.restriction?[0].enumeration
       type.xsdChildrenMode = 'restriction'

--- a/lib/xsdParser.coffee
+++ b/lib/xsdParser.coffee
@@ -329,9 +329,13 @@ module.exports =
           atom.notifications.addError "can't find base type " + extenType.$.base
           continue
 
+        # Get extending elements to merge them with linkType children
+        extendingType = @initTypeObject null, "someType"
+        @parseComplexType extenType, extendingType
+
         type.xsdTypeName = linkType.xsdTypeName
         type.xsdChildrenMode = linkType.xsdChildrenMode
-        type.xsdChildren = linkType.xsdChildren
+        type.xsdChildren = linkType.xsdChildren.concat extendingType.xsdChildren
         type.xsdAttributes = extenAttr.concat linkType.xsdAttributes
         type.description ?= linkType.description
         type.type = linkType.type

--- a/lib/xsdParser.coffee
+++ b/lib/xsdParser.coffee
@@ -109,6 +109,37 @@ module.exports =
     str?.replace?(/[\n\r]/, '').trim()
 
 
+  ## Return true if built-in types
+  isBuiltInType: (typeName) ->
+    parts = typeName.split ':'
+    # Built-in types have to be prefixed with XSD schema prefix
+    if parts.length != 2
+      return false
+    # TODO check namespace prefix, I'm not sure how to do that
+    # Check built-in type names
+    return parts[1] in [
+      'string',
+      'boolean',
+      'decimal',
+      'float',
+      'double',
+      'duration',
+      'dateTime',
+      'time',
+      'date',
+      'gYearMonth',
+      'gYear',
+      'gMonthDay',
+      'gDay',
+      'gMonth',
+      'hexBinary',
+      'base64Binary',
+      'anyURI',
+      'QName',
+      'NOTATION'
+    ]
+
+
   ## Get documentation string from node
   getDocumentation: (node) ->
     @normalizeString(node?.annotation?[0].documentation[0]._ ?
@@ -333,7 +364,7 @@ module.exports =
         linkType = @types[extenType.$.base]
         if not linkType
           # Ingore link type for simple types reffering to standard simple types like xs:string, etc.
-          if type.xsdType == 'simple' and ":" in extenType.$.base
+          if type.xsdType == 'simple' and @isBuiltInType(extenType.$.base)
             linkType = @initTypeObject null, type.xsdTypeName
           else
             atom.notifications.addError "can't find base type " + extenType.$.base
@@ -370,11 +401,17 @@ module.exports =
 
       # If it's a list
       else if type.xsdChildrenMode == 'list'
-        listType = @types[type.leftLabel]
-        if not listType
-          atom.notifications.addError "can't find item type " + type.leftLabel
-          continue
-        type.xsdChildren = listType.xsdChildren
+        itemType = type.leftLabel
+        if not @isBuiltInType(itemType)
+          listType = @types[itemType]
+          if not listType
+            atom.notifications.addError "can't find item type " + itemType
+            continue
+          type.xsdChildren = listType.xsdChildren
+          type.leftLabel = ''
+        else
+          type.leftLabel = 'list of '.concat(type.leftLabel)
+
 
       # Resolve all groups in type
       newChildren = []

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "xml2js": "0.4.15",
-    "uuid": "^2.0.1"
+    "uuid": "^2.0.1",
+    "xml2js": "^0.4.15"
   },
   "providedServices": {
     "autocomplete.provider": {

--- a/package.json
+++ b/package.json
@@ -31,10 +31,5 @@
         "^1.0.0": "consumeStatusBar"
       }
     }
-  },
-  "apmInstallSource": {
-    "type": "git",
-    "source": "ph777/atom-autocomplete-xml",
-    "sha": "7f668754afc216fd21f2600b04dc9481b7e95bfd"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,5 +31,10 @@
         "^1.0.0": "consumeStatusBar"
       }
     }
+  },
+  "apmInstallSource": {
+    "type": "git",
+    "source": "ph777/atom-autocomplete-xml",
+    "sha": "7f668754afc216fd21f2600b04dc9481b7e95bfd"
   }
 }


### PR DESCRIPTION
This PR adds support for `<xs:list itemType="..."/>`.

The commit follows the previous PRs. I don't know how to make it independent of previous commits, sorry for that. However, the only commit that is really needed for this PR is 
[d104303](https://github.com/pleonex/atom-autocomplete-xml/commit/d104303b6b8748afa40ba0107741b62f696c3ac4).

Please review and merge if possible. Thanks!