### PR TITLE
Add support for xml:lang in xs:description element

### DIFF
--- a/lib/xsdParser.coffee
+++ b/lib/xsdParser.coffee
@@ -111,9 +111,23 @@ module.exports =
 
   ## Get documentation string from node
   getDocumentation: (node) ->
-    @normalizeString(node?.annotation?[0].documentation[0]._ ?
-      node?.annotation?[0].documentation[0])
+    langUser = navigator.language
+    docs = node?.annotation?[0].documentation
+    if ! docs
+      return null
 
+    docEn = null
+    docAny = null
+    for doc in docs
+      langDoc = doc.$?.lang
+      if langDoc == langUser
+        return @normalizeString(doc._)
+      if langDoc == 'en'
+        docEn = doc
+      else
+        docAny = doc
+    return @normalizeString(if docEn then docEn._ else
+        if docAny then docAny._)
 
   # Initialize a type object from a Simple or Complex type node.
   initTypeObject: (node, typeName) ->
@@ -372,3 +386,4 @@ module.exports =
         else
           attributes.push attr
       type.xsdAttributes = attributes
+


### PR DESCRIPTION
This PR adds ability to offer XSD's documentation texts in the preferred language as recognized by `navigator.language`.

```xml
<xs:complexType name="myType">
      <xs:sequence>
            <xs:element name="my-elem" type="myElemType">
                <xs:annotation>
                    <xs:documentation xml:lang="en">
                        Use my-elem to specify...
                    </xs:documentation>
                    <xs:documentation xml:lang="cs">
                        Použij my-elem pro...
                    </xs:documentation>
                </xs:annotation>
            </xs:element>
      </xs:sequence>
</xs:complexType>
```
