### PR TITLE
Add support for enumeration annotation

### DIFF
--- a/lib/xsd.coffee
+++ b/lib/xsd.coffee
@@ -176,6 +176,7 @@ module.exports =
     displayText: child.tagName
     type: 'value'
     rightLabel: 'Value'
+    description: child.description
 
   ## Called when suggestion requested for attributes.
   getAttributes: (xpath) ->

--- a/lib/xsdParser.coffee
+++ b/lib/xsdParser.coffee
@@ -161,10 +161,11 @@ module.exports =
       type.xsdChildren.push group
 
       for val in childrenNode.enumeration
+        doc = @getDocumentation val
         group.elements.push {
           tagName: val.$.value
           xsdTypeName: null
-          description: ''
+          description: doc
           minOccurs: 0
           maxOccurs: 1
         }

--- a/lib/xsdParser.coffee
+++ b/lib/xsdParser.coffee
@@ -147,6 +147,9 @@ module.exports =
     else if node.union
       type.xsdChildrenMode = 'union'
       type.leftLabel = node.union[0].$.memberTypes
+    else if node.list
+      type.xsdChildrenMode = 'list'
+      type.leftLabel = node.list[0].$.itemType
 
     if childrenNode
       group =
@@ -353,6 +356,14 @@ module.exports =
         for t in unionTypes
           memberType = @types[t]
           type.xsdChildren.push memberType.xsdChildren[0] if memberType
+
+      # If it's a list
+      else if type.xsdChildrenMode == 'list'
+        listType = @types[type.leftLabel]
+        if not listType
+          atom.notifications.addError "can't find item type " + type.leftLabel
+          continue
+        type.xsdChildren = listType.xsdChildren
 
       # At the moment, I think it only makes sense if it replaces all the
       # elements. Consider a group that contains a sequence of choice elements.

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "xml2js": "0.4.15",
-    "uuid": "^2.0.1"
+    "uuid": "^2.0.1",
+    "xml2js": "^0.4.15"
   },
   "providedServices": {
     "autocomplete.provider": {


### PR DESCRIPTION
This simple PR enhances XSD support by offering description for enumeration values.

```xml
<xs:simpleType name="myType">
  <xs:restriction base="xs:string">
    <xs:enumeration value="myValue">
      <xs:annotation>
        <xs:documentation xml:lang="en">
           This is a description that will be displayed for myValue.
        </xs:documentation>
      </xs:annotation>
    </xs:enumeration>
  </xs:restriction>
</xs:simpleType>
```
Please review this PR.