### PR TITLE
Resolve issue with HTTP 302 response codes

### DIFF
--- a/lib/xsd.coffee
+++ b/lib/xsd.coffee
@@ -14,9 +14,9 @@ module.exports =
     # Get the protocol used to download the file.
     protocol = null
     if xsdUri.substr(0, 7) is "http://"
-      protocol = require 'http'
+      protocol = require 'follow-redirects'.http
     else if xsdUri.substr(0, 8) is "https://"
-      protocol = require 'https'
+      protocol = require 'follow-redirects'.https
 
     if protocol
       # Download the file

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "uuid": "^3.2.1",
-    "xml2js": "^0.4.19"
+    "xml2js": "^0.4.19",
+    "follow-redirects": "^1.5.10"
   },
   "providedServices": {
     "autocomplete.provider": {


### PR DESCRIPTION
Currently, the retrieval of the XSD doesn't handle the case where the server returns a 302 response code with a Location HTTP header to point to the correct location for the XSD.

This PR adds the "follow-redirects" dependency and uses it as a wrapper to automatically handle the redirects.